### PR TITLE
将“漫画语言快捷按钮”脚本的z-index调整到合适的数值:10

### DIFF
--- a/TranslatedJump/EhTagTranslatedJump.user.js
+++ b/TranslatedJump/EhTagTranslatedJump.user.js
@@ -66,7 +66,7 @@ GM_addStyle(`
     position: absolute;
     top: -1px;
     right: -1px;
-    z-index: 99999999;
+    z-index: 10;
     background: inherit;
     border: inherit;
     padding: 0 8px;


### PR DESCRIPTION
tj-box的z-index值99999999实在太大，影响到了其他脚本。我观察了一下同一级的标题元素 `gd2`，z-index值为2，因此`tj-box`的z-index设置为10较为合理。