### PR TITLE
Fix tag voting status visibility after coloring

### DIFF
--- a/DetailPageTagColor/EhDetailPageTagColor.user.js
+++ b/DetailPageTagColor/EhDetailPageTagColor.user.js
@@ -84,8 +84,28 @@ async function dyeing() {
             border-color: ${v.borderColor} !important;
             background: ${v.background} !important;
         }
+        [id="td_${v.tag.replaceAll(' ', '_')}"].gtw, [id="td_${v.tag.replaceAll(' ', '_')}"].gtl{
+            outline: solid 1px ${v.borderColor};
+            border-color: ${v.color} !important;
+        }
         [id="td_${v.tag.replaceAll(' ', '_')}"] a {
             color: ${v.color};
+        }
+        .tup::after {
+            display: inline-block;
+            background-color: green;
+            color: #fff;
+            border-radius: 2px;
+            margin-left: 2px;
+            content: '↾';
+        }
+        .tdn::after {
+            background-color: red;
+            color: #fff;
+            border-radius: 2px;
+            display: inline-block;
+            margin-left: 2px;
+            content: '⇂';
         }
         `
     });

--- a/DetailPageTagColor/EhDetailPageTagColor.user.js
+++ b/DetailPageTagColor/EhDetailPageTagColor.user.js
@@ -1,15 +1,15 @@
 // ==UserScript==
 // @name         eh详情页标签颜色
 // @namespace    com.xioxin.tag-color
-// @version      0.6
+// @version      0.7
 // @description  eh为详情页标签增加颜色
 // @author       xioxin
 // @homepage     https://github.com/EhTagTranslation/UserScripts
 // @supportURL   https://github.com/EhTagTranslation/UserScripts/issues
-// @include     *://exhentai.org/g/*
-// @include     *://e-hentai.org/g/*
-// @include     *://exhentai.org/mytags
-// @include     *://e-hentai.org/mytags
+// @match     *://exhentai.org/g/*
+// @match     *://e-hentai.org/g/*
+// @match     *://exhentai.org/mytags
+// @match     *://e-hentai.org/mytags
 // @grant    GM_addStyle
 // @grant    GM_getValue
 // @grant    GM_setValue
@@ -25,7 +25,7 @@ if(typeof GM_addStyle == 'undefined') {
         var style = document.createElement("style");
         style.type = "text/css";
         style.innerHTML=script
-        document.getElementsByTagName("HEAD").item(0).appendChild(style); 
+        document.getElementsByTagName("HEAD").item(0).appendChild(style);
     }
 }
 if(typeof GM_setValue == 'undefined') {
@@ -79,33 +79,35 @@ async function dyeing() {
     const myTags = GM_getValue("myTags", []);
     let css = '';
     myTags.forEach(v => {
+        const key = v.tag.replaceAll(' ', '_');
         css += `
-        [id="td_${v.tag.replaceAll(' ', '_')}"]{
+        [id="td_${key}"]{
             border-color: ${v.borderColor} !important;
             background: ${v.background} !important;
         }
-        [id="td_${v.tag.replaceAll(' ', '_')}"].gtw, [id="td_${v.tag.replaceAll(' ', '_')}"].gtl{
+        [id="td_${key}"].gtw, [id="td_${key}"].gtl{
             outline: solid 1px ${v.borderColor};
             border-color: ${v.color} !important;
         }
-        [id="td_${v.tag.replaceAll(' ', '_')}"] a {
+        [id="td_${key}"] a {
             color: ${v.color};
         }
-        .tup::after {
+        .tup::after, .tdn::after {
             display: inline-block;
-            background-color: green;
             color: #fff;
-            border-radius: 2px;
-            margin-left: 2px;
-            content: '↾';
+            border-radius: 4px;
+            margin-left: 4px;
+            margin-right: -2px;
+            background-color: green;
+            content: '';
+            line-height: 14px;
+            outline: solid 1px #fff;
+            vertical-align: sub;
+            width: 4px;
+            height: 14px;
         }
         .tdn::after {
             background-color: red;
-            color: #fff;
-            border-radius: 2px;
-            display: inline-block;
-            margin-left: 2px;
-            content: '⇂';
         }
         `
     });


### PR DESCRIPTION
Fixes #24

Add functionality to display tag voting status on the gallery detail page after coloring.

* Add CSS rules to set the border color of tags with `gtw` or `gtl` class to the text color.
* Add CSS rules to display an icon next to each tag indicating the voting status.
* Use CSS pseudo-elements and pseudo-classes to achieve the desired styling.
* Ensure the tag voting status is visible and clear even after applying the coloring script.

![img](https://github.com/user-attachments/assets/1301b4f4-66f2-4fc0-b229-7a4d0160f174)


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EhTagTranslation/UserScripts/issues/24?shareId=8de2ac65-a06a-4988-9b53-5c0847dd2241).